### PR TITLE
Clean up unused aliases

### DIFF
--- a/lib/searchex/adapter/shake/filesys.ex
+++ b/lib/searchex/adapter/shake/filesys.ex
@@ -31,7 +31,6 @@ defmodule Searchex.Adapter.Shake.Filesys do
 
   def expand_file_roots(frame, _opts) do
     alias Searchex.Command.CmdHelpers
-    alias Searchex.Command.Build.Catalog.Params
     new_roots  = CmdHelpers.expanded_file_roots(frame)
     new_params = put_in(frame.params, [Access.key(:adapter, nil), :file_roots], new_roots)
     %Frame{frame | params: new_params}

--- a/lib/searchex/command/cmd_helpers.ex
+++ b/lib/searchex/command/cmd_helpers.ex
@@ -25,7 +25,6 @@ defmodule Searchex.Command.CmdHelpers do
   end
 
   def doc_size(frame) do
-    alias Searchex.Command.Build.Catalog.Params
     roots = expanded_file_roots(frame)
 #    Util.Ext.File.du_s(roots, Params.file_params(frame.params))
     Util.Ext.File.du_s(roots, Searchex.Adapter.Type.Filesys.file_params(frame.params))

--- a/lib/searchex/command/params.ex
+++ b/lib/searchex/command/params.ex
@@ -42,7 +42,6 @@ defmodule Searchex.Command.Params do
   end
 
   def validate_matching_cfg_names(frame, _opts) do
-    alias Searchex.Command.CmdHelpers
     frame_name = String.split(frame.cfg_name, "/") |> Enum.at(1)
     coll_name  = frame.params.collection
     case frame_name == coll_name do
@@ -58,9 +57,6 @@ defmodule Searchex.Command.Params do
   # TODO: USE THE CURSOR FROM THE ADAPTER!!
   # ALSO: SEPARATE DIGESTS FOR DOCSOURCE AND PARAMS!!
   def generate_digest(%Frame{cfg_name: cfg_name} = frame, _opts) do
-    alias Searchex.Config.CfgHelpers
-    alias Searchex.Command.CmdHelpers
-    alias Util.TimeStamp
 #    term  = [CfgHelpers.cfg_file(cfg_name)] ++ CmdHelpers.file_list(frame)
 #            |> Enum.map(fn(file) -> TimeStamp.filepath_timestamp(file) end)
 #            |> TimeStamp.newest


### PR DESCRIPTION
Removes some unused aliases.

Before change:

    $ mix compile
    Compiling 64 files (.ex)
    warning: unused alias Params
      lib/searchex/adapter/shake/filesys.ex:34

    warning: unused alias Params
      lib/searchex/command/cmd_helpers.ex:28

    warning: unused alias CfgHelpers
      lib/searchex/command/params.ex:61

    warning: unused alias CmdHelpers
      lib/searchex/command/params.ex:62

    warning: unused alias TimeStamp
      lib/searchex/command/params.ex:63

    Generated searchex app

After change

    $ mix compile
    Compiling 8 files (.ex)
